### PR TITLE
fix: resolve skill root for init and upgrade

### DIFF
--- a/src/cli/cmd-init.ts
+++ b/src/cli/cmd-init.ts
@@ -15,6 +15,7 @@ import {
   scaffoldContentFiles,
   writeTemplate,
 } from '../project/scaffold.js'
+import { resolveSkillRoot } from '../utils/path.js'
 
 export interface InitOptions {
   root: string
@@ -60,7 +61,7 @@ export function cmdInit(options: InitOptions): number {
     return 1
   }
 
-  const skillRoot = resolve(new URL(import.meta.url).pathname.replace(/^\/([a-zA-Z]:)/, '$1'), '..', '..', '..')
+  const skillRoot = resolveSkillRoot(import.meta.url)
   const templates = resolveTemplateDir(skillRoot, root, options.locale)
   const dt = buildDatetime(options.date, options.time)
 

--- a/src/cli/cmd-upgrade.ts
+++ b/src/cli/cmd-upgrade.ts
@@ -9,6 +9,7 @@ import { resolve } from 'node:path'
 import { normalizeLocale } from '../project/locale.js'
 import { buildDatetime, resolveTemplateDir } from '../project/scaffold.js'
 import { upgrade, formatResultText } from '../project/upgrade.js'
+import { resolveSkillRoot } from '../utils/path.js'
 
 export interface UpgradeOptions {
   root: string
@@ -27,7 +28,7 @@ export function cmdUpgrade(options: UpgradeOptions): number {
     return 1
   }
 
-  const skillRoot = resolve(new URL(import.meta.url).pathname.replace(/^\/([a-zA-Z]:)/, '$1'), '..', '..', '..')
+  const skillRoot = resolveSkillRoot(import.meta.url)
   const templates = resolveTemplateDir(skillRoot, root, options.locale)
   const effectiveLocale = normalizeLocale(options.locale, root)
   const dt = buildDatetime(options.date, options.time)

--- a/src/utils/path.ts
+++ b/src/utils/path.ts
@@ -1,4 +1,6 @@
-import { normalize } from 'node:path'
+import { existsSync } from 'node:fs'
+import { dirname, join, normalize, resolve } from 'node:path'
+import { fileURLToPath } from 'node:url'
 
 /**
  * Convert a file path to posix format (forward slashes).
@@ -6,4 +8,24 @@ import { normalize } from 'node:path'
  */
 export function toPosixPath(p: string): string {
   return normalize(p.replace(/\\/g, '/').replace(/\/+/g, '/')).replace(/\\/g, '/')
+}
+
+/**
+ * Resolve the installed skill root from a module URL.
+ * Works for both source execution (`src/**`) and built execution (`dist/**`).
+ */
+export function resolveSkillRoot(moduleUrl: string): string {
+  let current = dirname(fileURLToPath(moduleUrl))
+
+  while (true) {
+    if (existsSync(join(current, 'SKILL.md')) && existsSync(join(current, 'assets', 'templates'))) {
+      return current
+    }
+
+    const parent = resolve(current, '..')
+    if (parent === current) {
+      throw new Error(`Unable to resolve skill root from ${moduleUrl}`)
+    }
+    current = parent
+  }
 }

--- a/tests/cli/init-upgrade.test.ts
+++ b/tests/cli/init-upgrade.test.ts
@@ -1,0 +1,82 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { existsSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs'
+import { join } from 'node:path'
+import { tmpdir } from 'node:os'
+
+import { cmdInit } from '../../src/cli/cmd-init.js'
+import { cmdUpgrade } from '../../src/cli/cmd-upgrade.js'
+
+let tmpDir: string
+
+beforeEach(() => {
+  tmpDir = mkdtempSync(join(tmpdir(), 'memorytree-cli-test-'))
+})
+
+afterEach(() => {
+  rmSync(tmpDir, { recursive: true, force: true })
+  vi.restoreAllMocks()
+})
+
+describe('cmdInit', () => {
+  it('initializes a repo with auto locale using installed templates', () => {
+    const result = cmdInit({
+      root: tmpDir,
+      projectName: 'demo-project',
+      goalSummary: 'Build a durable project memory workflow.',
+      locale: 'auto',
+      date: '2025-06-15',
+      time: '14:30',
+      skipAgents: false,
+      force: false,
+    })
+
+    expect(result).toBe(0)
+    expect(existsSync(join(tmpDir, 'AGENTS.md'))).toBe(true)
+    expect(existsSync(join(tmpDir, 'Memory', '01_goals', 'goal_v001_20250615.md'))).toBe(true)
+    expect(existsSync(join(tmpDir, 'Memory', '02_todos', 'todo_v001_001_20250615.md'))).toBe(true)
+    expect(existsSync(join(tmpDir, 'Memory', '03_chat_logs', '2025-06-15_14-30.md'))).toBe(true)
+  })
+})
+
+describe('cmdUpgrade', () => {
+  it('upgrades a repo with auto locale using installed templates', () => {
+    const stdout = vi.spyOn(process.stdout, 'write').mockImplementation(() => true)
+
+    const result = cmdUpgrade({
+      root: tmpDir,
+      projectName: 'demo-project',
+      goalSummary: 'Build a durable project memory workflow.',
+      locale: 'auto',
+      date: '2025-06-15',
+      time: '14:30',
+      format: 'json',
+    })
+
+    expect(result).toBe(0)
+    expect(existsSync(join(tmpDir, 'AGENTS.md'))).toBe(true)
+    expect(existsSync(join(tmpDir, 'Memory', '01_goals', 'goal_v001_20250615.md'))).toBe(true)
+
+    const output = stdout.mock.calls.map(call => String(call[0])).join('')
+    expect(output).toContain('"state_before":"not-installed"')
+    expect(output).toContain('"state_after":"installed"')
+  })
+
+  it('writes scaffolded content from the expected template set', () => {
+    vi.spyOn(process.stdout, 'write').mockImplementation(() => true)
+    writeFileSync(join(tmpDir, 'README.md'), '# Demo Project\n\nThis repository uses English documentation.\n')
+
+    cmdUpgrade({
+      root: tmpDir,
+      projectName: 'demo-project',
+      goalSummary: 'Build a durable project memory workflow.',
+      locale: 'auto',
+      date: '2025-06-15',
+      time: '14:30',
+      format: 'text',
+    })
+
+    const goal = readFileSync(join(tmpDir, 'Memory', '01_goals', 'goal_v001_20250615.md'), 'utf-8')
+    expect(goal).toContain('# Project Goal v001')
+    expect(goal).toContain('Build a durable project memory workflow.')
+  })
+})


### PR DESCRIPTION
## Summary

- fix `memorytree init` and `memorytree upgrade` template lookup when running from built `dist` output
- replace fixed `.. / .. / ..` path traversal with skill-root discovery based on actual repository markers
- add CLI regression tests covering `locale=auto` for both `cmdInit` and `cmdUpgrade`

## Verification

- ran `npm run typecheck`
- ran `npm run test`
- ran `npm run build`
- verified `node dist/cli.js init --root <tmp> --locale auto` succeeds
- verified `node dist/cli.js upgrade --root <tmp> --locale auto --format json` succeeds

Closes #4
