### PR TITLE
fix: keep heartbeat off non-memorytree branches

### DIFF
--- a/src/heartbeat/heartbeat.ts
+++ b/src/heartbeat/heartbeat.ts
@@ -98,6 +98,15 @@ export async function processProject(config: Config, projectPath: string, projec
   const logger = getLogger()
   const repoSlug = slugify(projectName, 'project')
   const globalRoot = defaultGlobalTranscriptRoot()
+  const branch = currentBranch(projectPath)
+  const mirrorToRepo = isDedicatedMemorytreeBranch(branch)
+
+  if (!mirrorToRepo) {
+    logger.warn(
+      `[${projectName}] Current branch '${branch}' is not a dedicated memorytree/* branch. ` +
+      'Importing to the global archive only.',
+    )
+  }
 
   const discovered = discoverSourceFiles()
   let importedCount = 0
@@ -117,7 +126,7 @@ export async function processProject(config: Config, projectPath: string, projec
     scanSensitive(parsed, projectPath)
 
     try {
-      await importTranscript(parsed, projectPath, globalRoot, repoSlug, 'not-set', true)
+      await importTranscript(parsed, projectPath, globalRoot, repoSlug, 'not-set', mirrorToRepo)
       importedCount++
     } catch {
       logger.exception(`Failed to import transcript: ${source}`)
@@ -130,7 +139,11 @@ export async function processProject(config: Config, projectPath: string, projec
   }
 
   logger.info(`[${projectName}] Imported ${importedCount} transcript(s).`)
-  gitCommitAndPush(config, projectPath, projectName, importedCount)
+  if (mirrorToRepo) {
+    gitCommitAndPush(config, projectPath, projectName, importedCount)
+  } else {
+    logger.info(`[${projectName}] Skipped repo-local commit/push on branch '${branch}'.`)
+  }
 }
 
 // ---------------------------------------------------------------------------
@@ -205,4 +218,12 @@ export function tryPush(projectPath: string, projectName: string): boolean {
   } catch {
     return false
   }
+}
+
+export function currentBranch(projectPath: string): string {
+  return git(projectPath, 'rev-parse', '--abbrev-ref', 'HEAD').trim()
+}
+
+export function isDedicatedMemorytreeBranch(branch: string): boolean {
+  return branch.trim().startsWith('memorytree/')
 }

--- a/tests/heartbeat/branch-safety.test.ts
+++ b/tests/heartbeat/branch-safety.test.ts
@@ -1,0 +1,153 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import type { ParsedTranscript } from '../../src/types/transcript.js'
+
+const mocks = vi.hoisted(() => ({
+  discoverSourceFiles: vi.fn(),
+  transcriptMatchesRepo: vi.fn(),
+  defaultGlobalTranscriptRoot: vi.fn(),
+  importTranscript: vi.fn(),
+  transcriptHasContent: vi.fn(),
+  parseTranscript: vi.fn(),
+  slugify: vi.fn(),
+  loadConfig: vi.fn(),
+  acquireLock: vi.fn(),
+  releaseLock: vi.fn(),
+  resetFailureCount: vi.fn(),
+  writeAlert: vi.fn(),
+  writeAlertWithThreshold: vi.fn(),
+  getLogger: vi.fn(),
+  setupLogging: vi.fn(),
+  git: vi.fn(),
+  toPosixPath: vi.fn(),
+}))
+
+vi.mock('../../src/transcript/discover.js', () => ({
+  discoverSourceFiles: mocks.discoverSourceFiles,
+  transcriptMatchesRepo: mocks.transcriptMatchesRepo,
+  defaultGlobalTranscriptRoot: mocks.defaultGlobalTranscriptRoot,
+}))
+
+vi.mock('../../src/transcript/import.js', () => ({
+  importTranscript: mocks.importTranscript,
+  transcriptHasContent: mocks.transcriptHasContent,
+}))
+
+vi.mock('../../src/transcript/parse.js', () => ({
+  parseTranscript: mocks.parseTranscript,
+}))
+
+vi.mock('../../src/transcript/common.js', () => ({
+  slugify: mocks.slugify,
+}))
+
+vi.mock('../../src/heartbeat/config.js', () => ({
+  loadConfig: mocks.loadConfig,
+}))
+
+vi.mock('../../src/heartbeat/lock.js', () => ({
+  acquireLock: mocks.acquireLock,
+  releaseLock: mocks.releaseLock,
+}))
+
+vi.mock('../../src/heartbeat/alert.js', () => ({
+  resetFailureCount: mocks.resetFailureCount,
+  writeAlert: mocks.writeAlert,
+  writeAlertWithThreshold: mocks.writeAlertWithThreshold,
+}))
+
+vi.mock('../../src/heartbeat/log.js', () => ({
+  getLogger: mocks.getLogger,
+  setupLogging: mocks.setupLogging,
+}))
+
+vi.mock('../../src/utils/exec.js', () => ({
+  git: mocks.git,
+}))
+
+vi.mock('../../src/utils/path.js', async () => {
+  const actual = await vi.importActual<typeof import('../../src/utils/path.js')>('../../src/utils/path.js')
+  return {
+    ...actual,
+    toPosixPath: mocks.toPosixPath,
+  }
+})
+
+import { isDedicatedMemorytreeBranch, processProject } from '../../src/heartbeat/heartbeat.js'
+
+function makeTranscript(): ParsedTranscript {
+  return {
+    client: 'codex',
+    session_id: 'sess-1',
+    title: 'Test session',
+    started_at: '2024-01-01T00:00:00Z',
+    cwd: 'D:/repo',
+    branch: 'main',
+    messages: [{ role: 'user', text: 'hello', timestamp: '2024-01-01T00:00:00Z' }],
+    tool_events: [],
+    source_path: 'C:/tmp/rollout-1.jsonl',
+  }
+}
+
+beforeEach(() => {
+  vi.clearAllMocks()
+
+  mocks.discoverSourceFiles.mockReturnValue([['codex', 'C:/tmp/rollout-1.jsonl']])
+  mocks.transcriptMatchesRepo.mockReturnValue(true)
+  mocks.defaultGlobalTranscriptRoot.mockReturnValue('C:/Users/ai/.memorytree/transcripts')
+  mocks.transcriptHasContent.mockReturnValue(true)
+  mocks.parseTranscript.mockReturnValue(makeTranscript())
+  mocks.importTranscript.mockResolvedValue({})
+  mocks.slugify.mockReturnValue('demo-project')
+  mocks.loadConfig.mockReturnValue({})
+  mocks.acquireLock.mockReturnValue(true)
+  mocks.toPosixPath.mockImplementation((value: string) => value)
+
+  mocks.getLogger.mockReturnValue({
+    info: vi.fn(),
+    warn: vi.fn(),
+    debug: vi.fn(),
+    error: vi.fn(),
+    exception: vi.fn(),
+  })
+})
+
+describe('isDedicatedMemorytreeBranch', () => {
+  it('matches memorytree/* branches only', () => {
+    expect(isDedicatedMemorytreeBranch('memorytree/transcripts')).toBe(true)
+    expect(isDedicatedMemorytreeBranch('memorytree/openmnemo')).toBe(true)
+    expect(isDedicatedMemorytreeBranch('main')).toBe(false)
+    expect(isDedicatedMemorytreeBranch('feature/memorytree')).toBe(false)
+  })
+})
+
+describe('processProject branch safety', () => {
+  it('imports to global archive only when the current branch is not memorytree/*', async () => {
+    mocks.git.mockImplementation((_cwd: string, ...args: string[]) => {
+      if (args[0] === 'rev-parse') return 'main\n'
+      throw new Error(`unexpected git call: ${args.join(' ')}`)
+    })
+
+    await processProject({ auto_push: true } as never, 'D:/repo', 'demo-project')
+
+    expect(mocks.importTranscript).toHaveBeenCalledTimes(1)
+    expect(mocks.importTranscript.mock.calls[0]?.[5]).toBe(false)
+    expect(mocks.git).toHaveBeenCalledTimes(1)
+  })
+
+  it('allows repo-local commit and push when already on a memorytree/* branch', async () => {
+    mocks.git.mockImplementation((_cwd: string, ...args: string[]) => {
+      if (args[0] === 'rev-parse') return 'memorytree/transcripts\n'
+      if (args[0] === 'status') return ' M Memory/06_transcripts/clean/codex/2024/01/file.md\n'
+      if (args[0] === 'remote') return 'origin\n'
+      return ''
+    })
+
+    await processProject({ auto_push: true } as never, 'D:/repo', 'demo-project')
+
+    expect(mocks.importTranscript).toHaveBeenCalledTimes(1)
+    expect(mocks.importTranscript.mock.calls[0]?.[5]).toBe(true)
+    expect(mocks.git).toHaveBeenCalledWith('D:/repo', 'add', 'Memory/')
+    expect(mocks.git).toHaveBeenCalledWith('D:/repo', 'commit', '-m', 'memorytree(transcripts): import 1 transcript(s)')
+    expect(mocks.git).toHaveBeenCalledWith('D:/repo', 'push')
+  })
+})


### PR DESCRIPTION
## Summary

- stop heartbeat repo-local transcript mirroring when the current branch is not `memorytree/*`
- keep importing matching transcripts into the global archive in that case
- skip repo-local commit/push unless the repo is already on a dedicated MemoryTree branch
- add heartbeat regression tests for branch safety

## Why this change

The documented Git policy describes a dedicated `memorytree/*` branch and PR-oriented flow, but the current heartbeat implementation was committing and pushing the currently checked out branch directly.

This PR is an immediate guardrail. It does **not** claim to implement the full isolated branch/PR workflow yet. Instead, it prevents the most dangerous behavior now: background repo-local writes and auto-push from a user's active branch such as `main`.

## Verification

- ran `npm run test`
- ran `npm run build`
- added tests covering:
  - non-`memorytree/*` branch -> global archive only, no repo commit/push
  - `memorytree/*` branch -> existing repo-local commit/push flow still works

Closes #6
