### PR TITLE
docs: clarify opt-in CI optimization for MemoryTree PRs

### DIFF
--- a/README.md
+++ b/README.md
@@ -180,6 +180,8 @@ MemoryTree follows strict isolation rules to never interfere with your repo's wo
 
 The skill stops and asks before proceeding in 8 scenarios: mixed product code, AGENTS.md conflicts, unclear target branch, repo forbids bot pushes, CI conflicts, unknown raw transcript permission, cross-project transcripts, or protected branch refusal.
 
+If a repository wants lighter CI for MemoryTree-only PRs, treat that as an explicit opt-in. Prefer path filters or dedicated lightweight workflows for `Memory/**` and managed `AGENTS.md`, and ask before changing workflow or required-check settings.
+
 For the full policy see [`references/git-policy.md`](references/git-policy.md).
 
 ### Sensitive Info Scanning

--- a/SKILL.md
+++ b/SKILL.md
@@ -96,6 +96,8 @@ Do not stop after detection to ask whether you should proceed. Act on the result
 9. When `auto_push` is enabled, the heartbeat process pushes automatically after committing. If no Git remote is configured, the push is skipped. If a push fails, the heartbeat retries once. In either case an alert is written to `~/.memorytree/alerts.json`. See `references/git-policy.md`.
 10. During transcript cleaning, the heartbeat scans for sensitive information (API keys, passwords, tokens). Matches are logged as warnings only — no automatic deletion or redaction. See `references/heartbeat-scheduling.md`.
 
+11. Do not modify the host repository's CI or E2E workflow definitions by default. If the user explicitly approves a MemoryTree-only optimization, prefer path-filtered or lightweight workflows for `Memory/**` and managed `AGENTS.md` PRs without weakening required branch protection.
+
 ## Resources
 
 - `references/project-detection.md`: detect install state and choose init vs maintain.

--- a/references/git-policy.md
+++ b/references/git-policy.md
@@ -8,6 +8,7 @@ MemoryTree must adapt to the host repository. It does not get to override it.
 - Do not stage or push unrelated user work.
 - Do not assume direct commits to protected branches are allowed.
 - Do not bypass review, CI, E2E, or release controls.
+- Do not modify the host repository's CI, E2E, branch protection, or required-check configuration by default.
 - Keep raw transcript files in the current project's transcript mirror by default, but exclude them from automatic staging unless the user explicitly approved raw transcript uploads for the current repository.
 - Do not mirror or stage transcript files from unrelated projects inside the current repository.
 
@@ -100,6 +101,14 @@ Notes:
 - State whether raw transcripts were included or intentionally left unstaged in the repo mirror.
 - Follow the repository's required target branch, review policy, and CI gates.
 
+## Optional CI Optimization For MemoryTree-Only PRs
+
+- If the repository owner explicitly approves it, MemoryTree-only PRs may use lighter CI for `Memory/**` and managed `AGENTS.md` changes.
+- Prefer repo-native path filters or dedicated lightweight workflows over disabling CI wholesale.
+- Keep branch protection and required checks coherent with the repository's governance model. Do not silently remove protections just to make MemoryTree PRs merge faster.
+- If the repository still requires full CI or E2E for documentation-only PRs, follow that stricter rule.
+- Ask the user before creating or editing workflow files, path filters, or required-check settings for this optimization.
+
 ## Stop And Ask
 
 Stop and ask the user before committing, pushing, or opening a PR when any of these are true:
@@ -112,3 +121,4 @@ Stop and ask the user before committing, pushing, or opening a PR when any of th
 6. Raw transcript upload permission for the repository is unknown.
 7. The diff includes raw transcripts or cleaned transcript indexes from other projects.
 8. `auto_push` is enabled but the target branch is a protected branch that refuses direct pushes.
+9. Enabling lighter CI for MemoryTree-only PRs would require changing workflow files, path filters, or required-check settings.


### PR DESCRIPTION
## Summary

- clarify that lighter CI/E2E for MemoryTree-only PRs is an explicit opt-in, not a silent default
- document that workflow or required-check changes must be user-approved
- recommend path filters or dedicated lightweight workflows instead of disabling CI wholesale

## Verification

- ran `npm run test`
- ran `npm run build`

## Notes

This is a policy/documentation clarification only. It does not add PR automation or CI workflow editing by itself.

Closes #8
